### PR TITLE
[Fix] 빈 식단 응답 캐시로 인해 최신 데이터가 반영되지 않는 문제 수정

### DIFF
--- a/lib/repositories/meal_repository.dart
+++ b/lib/repositories/meal_repository.dart
@@ -217,11 +217,9 @@ class MealRepository {
     final bool isToday = responseDate.isAtSameMomentAs(
       DateUtils.dateOnly(DateTime.now()),
     );
+    bool isEmptyResponse = false;
 
     await isar.writeTxn(() async {
-      // 1. 해당 날짜의 기존 Meal 데이터 삭제 (중복 방지)
-      await isar.meals.filter().dateEqualTo(responseDate).deleteAll();
-
       final newMeals = <Meal>[];
 
       for (var cafeteria in response.schools.cafeterias) {
@@ -234,6 +232,17 @@ class MealRepository {
         newMeals.addAll(meals);
       }
 
+      // Empty 응답은 성공 캐시로 저장하지 않습니다.
+      // 기존 Meal 데이터는 유지하고, cacheStatus만 제거해 다음 진입 시 API를 다시 호출하게 합니다.
+      if (newMeals.isEmpty) {
+        isEmptyResponse = true;
+        await isar.menuCacheStatuses.filter().dateEqualTo(responseDate).deleteAll();
+        return;
+      }
+
+      // 1. 해당 날짜의 기존 Meal 데이터 삭제 (중복 방지)
+      await isar.meals.filter().dateEqualTo(responseDate).deleteAll();
+
       // 2. 모든 Meal 객체 저장 및 링크 연결
       await _saveMealsAndLinks(newMeals);
 
@@ -242,7 +251,11 @@ class MealRepository {
     });
 
     if (kDebugMode) {
-      print("💾 DB 저장 완료: $responseDate");
+      if (isEmptyResponse) {
+        print("⚠️ [Empty Response] 캐시 갱신 없이 유지: $responseDate");
+      } else {
+        print("💾 DB 저장 완료: $responseDate");
+      }
     }
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
Closes BOB-87

## ✨ 작업 내용
- `MealRepository._saveMenuResponseToDb()` 로직 변경
- 이전: 응답이 비어도 기존 날짜 `Meal`을 지우고, `MenuCacheStatus`를 갱신해서 캐시 HIT 가능
- 이후: 응답이 비면
  - 해당 날짜 `Meal` 데이터는 삭제하지 않음(기존 데이터 보존)
  - `MenuCacheStatus`를 갱신하지 않음
  - 해당 날짜 캐시 상태를 제거해서 다음 진입 시 API 재호출 유도
- 응답에 실제 식단이 있을 때만 기존처럼
  - 날짜별 `Meal` 삭제 후 새 데이터 저장
  - 캐시 상태 갱신
- 디버그 로그 추가로 empty 응답 처리 경로를 구분 가능하게 함

## 효과:
- empty -> 정상 데이터 전환 시 Pull-to-Refresh 없이도 재진입/재실행에서 최신 데이터 반영 가능
- empty 응답이 24시간 캐시로 고정되는 문제 해소

## 🔎 변경 사항
- UI 변경 여부: X
- API 변경 여부: X
- 의존성 변경 여부: X

## ✅ 체크리스트
- [x] PR 제목 규칙 준수 ([태그] 제목)
- [ ] 빌드 테스트 완료
- [ ] 리뷰 반영 완료