### PR TITLE
[Fix] 학교 전환 시 식단 조회 정책 일원화 및 홈 즉시 갱신 보강

### DIFF
--- a/lib/providers/univ_provider.dart
+++ b/lib/providers/univ_provider.dart
@@ -1,13 +1,11 @@
 import 'dart:convert';
 
-import 'package:bobmoo/collections/meal_collection.dart';
-import 'package:bobmoo/collections/menu_cache_status.dart';
 import 'package:bobmoo/locator.dart';
 import 'package:bobmoo/models/university.dart';
+import 'package:bobmoo/repositories/meal_repository.dart';
 import 'package:bobmoo/services/analytics_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:isar_community/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class UnivProvider extends ChangeNotifier {
@@ -67,22 +65,17 @@ class UnivProvider extends ChangeNotifier {
       return;
     }
 
-    final isar = locator<Isar>();
-
     if (kDebugMode) {
       debugPrint(
-        '[UnivProvider] 학교 변경 감지: 기존 식단/캐시 데이터 초기화 시작 (meal, menuCacheStatus clear)',
+        '[UnivProvider] 학교 변경 감지: Repository를 통해 식단/캐시 무효화 시작',
       );
     }
 
-    // 학교가 변경되면 기존의 모든 이전 학교의 식단 및 캐시 삭제
-    await isar.writeTxn(() async {
-      await isar.meals.clear();
-      await isar.menuCacheStatuses.clear();
-    });
+    // 캐시 정책 책임은 Repository로 위임합니다.
+    await locator<MealRepository>().onSchoolChanged();
 
     if (kDebugMode) {
-      debugPrint('[UnivProvider] 기존 식단/캐시 데이터 초기화 완료');
+      debugPrint('[UnivProvider] Repository 캐시 무효화 완료');
     }
 
     _selectedUniversity = univ;

--- a/lib/repositories/meal_repository.dart
+++ b/lib/repositories/meal_repository.dart
@@ -44,7 +44,6 @@ class MealRepository {
   final MenuService menuService;
   final SharedPreferences prefs;
   static const String _fallbackSchoolNameK = '인하대학교';
-  static const String _lastFetchedSchoolNameKKey = 'lastFetchedSchoolNameK';
 
   MealRepository({
     required this.isar,
@@ -59,12 +58,29 @@ class MealRepository {
   }
 
   /// 핵심 함수(분석용): 특정 날짜 식단과 데이터 출처를 함께 반환
-  Future<MealFetchResult> getMealsForDateWithSource(DateTime date) async {
+  Future<MealFetchResult> getMealsForDateWithSource(
+    DateTime date, {
+    bool forceRefresh = false,
+  }) async {
+    return _fetchMealsWithPolicy(date, forceRefresh: forceRefresh);
+  }
+
+  /// UI에서 Pull-to-Refresh(당겨서 새로고침)를 위한 함수
+  Future<MealFetchResult> forceRefreshMeals(DateTime date) async {
+    return _fetchMealsWithPolicy(date, forceRefresh: true);
+  }
+
+  /// 학교 변경 시 호출: 기존 식단/캐시를 일괄 무효화합니다.
+  Future<void> onSchoolChanged() async {
+    await _clearAllMealCaches();
+  }
+
+  Future<MealFetchResult> _fetchMealsWithPolicy(
+    DateTime date, {
+    required bool forceRefresh,
+  }) async {
     final targetDate = DateUtils.dateOnly(date);
     final schoolNameK = _resolveSchoolNameK();
-    final lastFetchedSchoolNameK = prefs.getString(_lastFetchedSchoolNameKKey);
-    final isSchoolChanged =
-        lastFetchedSchoolNameK == null || lastFetchedSchoolNameK != schoolNameK;
 
     // 1. 해당 날짜의 캐시 상태 확인
     final cacheStatus = await isar.menuCacheStatuses
@@ -75,25 +91,20 @@ class MealRepository {
     final bool isCacheStale =
         cacheStatus == null ||
         DateTime.now().difference(cacheStatus.lastFetchedAt).inHours >= 24;
-    final shouldFetchFromApi = isCacheStale || isSchoolChanged;
+    final shouldFetchFromApi = forceRefresh || isCacheStale;
 
     if (shouldFetchFromApi) {
       // 2a. 캐시가 없거나 오래되었으면 API 호출
       if (kDebugMode) {
         print(
-          "ℹ️ [Cache Miss/Stale/SchoolChanged] API를 호출하여 데이터를 갱신합니다: $targetDate, school=$schoolNameK",
+          "ℹ️ [Cache Miss/Stale/ForceRefresh] API를 호출하여 데이터를 갱신합니다: $targetDate, school=$schoolNameK",
         );
       }
       try {
-        if (isSchoolChanged) {
-          // 학교 변경 시 이전 학교 캐시가 노출되지 않도록 로컬 캐시를 먼저 비웁니다.
-          await _clearAllMealCaches();
-        }
         final meals = await _fetchFromApiAndSave(
           targetDate,
           schoolNameK: schoolNameK,
         );
-        await prefs.setString(_lastFetchedSchoolNameKKey, schoolNameK);
         return MealFetchResult(
           meals: meals,
           dataSource: MealDataSource.apiFetched,
@@ -102,11 +113,6 @@ class MealRepository {
         if (kDebugMode) {
           print("🚨 [API Error] API 호출 실패: $e");
         }
-        // 학교 변경 직후에는 이전 학교 stale 데이터가 섞일 수 있어 fallback을 사용하지 않습니다.
-        if (isSchoolChanged) {
-          rethrow;
-        }
-
         // API 호출 실패 시, DB에 오래된 데이터라도 있는지 확인 후 반환
         final staleData = await fetchFromDb(targetDate);
         if (staleData.isNotEmpty) {
@@ -126,21 +132,6 @@ class MealRepository {
         dataSource: MealDataSource.dbHit,
       );
     }
-  }
-
-  /// UI에서 Pull-to-Refresh(당겨서 새로고침)를 위한 함수
-  Future<List<Meal>> forceRefreshMeals(DateTime date) async {
-    final targetDate = DateUtils.dateOnly(date);
-    final schoolNameK = _resolveSchoolNameK();
-    if (kDebugMode) {
-      print("🔄 [Force Refresh] 강제로 데이터를 새로고침합니다: $targetDate");
-    }
-    final meals = await _fetchFromApiAndSave(
-      targetDate,
-      schoolNameK: schoolNameK,
-    );
-    await prefs.setString(_lastFetchedSchoolNameKKey, schoolNameK);
-    return meals;
   }
 
   // --- Private Helper Methods ---

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -38,6 +38,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   final MealRepository _repository = locator<MealRepository>();
   late final HomeWidgetSyncHelper _widgetSyncHelper;
   late Future<List<Meal>> _mealFuture;
+  UnivProvider? _univProvider;
+  VoidCallback? _univListener;
+  int? _lastKnownSchoolId;
   Object? _mealLoadError;
   DateTime? _lastWidgetUpdateAt;
   static const Duration _widgetUpdateMinInterval = Duration(seconds: 30);
@@ -84,6 +87,9 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   /// 위젯이 영구적으로 제거될때 호출
   @override
   void dispose() {
+    if (_univProvider != null && _univListener != null) {
+      _univProvider!.removeListener(_univListener!);
+    }
     // 옵저버 제거
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -104,12 +110,48 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   void didChangeDependencies() {
     super.didChangeDependencies();
 
+    final provider = context.read<UnivProvider>();
+    // didChangeDependencies는 여러 번 호출될 수 있으므로,
+    // 동일 Provider 인스턴스에는 리스너를 중복 등록하지 않습니다.
+    if (_univProvider == provider) {
+      return;
+    }
+
+    // 상위 트리 재구성 등으로 Provider 인스턴스가 교체되면
+    // 기존 리스너를 해제한 뒤 새 인스턴스에 재등록합니다.
+    if (_univProvider != null && _univListener != null) {
+      _univProvider!.removeListener(_univListener!);
+    }
+
+    _univProvider = provider;
+    _lastKnownSchoolId = provider.selectedUniversity?.schoolId;
+    _univListener = _handleUniversityChanged;
+    _univProvider!.addListener(_univListener!);
+  }
+
+  void _handleUniversityChanged() {
+    if (!mounted) return;
+
+    final nextSchoolId = _univProvider?.selectedUniversity?.schoolId;
+    // 실제 학교가 바뀐 경우에만 재조회하고,
+    // 동일 schoolId 알림은 무시해 불필요한 호출을 막습니다.
+    if (nextSchoolId == _lastKnownSchoolId) {
+      return;
+    }
+    _lastKnownSchoolId = nextSchoolId;
+
     _analyticsHelper.setMealRequestContext(
       requestType: MealApiRequestType.universityChanged,
     );
+    // 학교 컨텍스트가 바뀌므로 empty/error 상태 노출 가드를 초기화합니다.
+    _analyticsHelper.resetStateExposureGuards();
 
-    _resetMealErrorState();
-    _mealFuture = _wrapMealFuture(_fetchData());
+    setState(() {
+      // 학교 변경 직후에는 새 학교의 오늘 식단을 기본 컨텍스트로 보여줍니다.
+      _selectedDate = DateUtils.dateOnly(DateTime.now());
+      _resetMealErrorState();
+      _mealFuture = _wrapMealFuture(_fetchData());
+    });
   }
 
   /// 인앱 업데이트를 확인하고, 가능하면 유연한 업데이트를 시작하는 함수
@@ -384,13 +426,15 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       _mealFuture = _wrapMealFuture(
         _repository
             .forceRefreshMeals(_selectedDate)
-            .then((meals) {
+            .then((result) {
+              final meals = result.meals;
+              final dataSource = _toAnalyticsDataSource(result.dataSource);
               if (schoolId != null) {
                 AnalyticsService.instance.logMealApiRequest(
                   schoolId: schoolId,
                   mealDate: mealDate,
                   requestType: MealApiRequestType.userPullToRefresh,
-                  dataSource: AnalyticsDataSource.apiFetched,
+                  dataSource: dataSource,
                   triggerSource: AnalyticsTriggerSource.foreground,
                   result: MealApiResult.success,
                 );
@@ -400,47 +444,48 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                   dateOffset: _analyticsHelper.dateOffsetFromToday(
                     _selectedDate,
                   ),
-                  dataSource: AnalyticsDataSource.apiFetched,
+                  dataSource: dataSource,
                   mealCount: meals.length,
                 );
               }
               return meals;
             })
-            .catchError((e) async {
-              // 1. API 호출이 실패하면 (SocketException, TimeoutException 등)
-              if (_isNetworkLikeError(e)) {
-                // 2. 로컬 DB에 저장된 데이터라도 있는지 확인합니다.
-                final localData = await _repository.fetchFromDb(_selectedDate);
-                if (localData.isNotEmpty) {
-                  if (schoolId != null) {
-                    AnalyticsService.instance.logMealApiRequest(
-                      schoolId: schoolId,
-                      mealDate: mealDate,
-                      requestType: MealApiRequestType.userPullToRefresh,
-                      dataSource: AnalyticsDataSource.dbStaleFallback,
-                      triggerSource: AnalyticsTriggerSource.foreground,
-                      result: MealApiResult.staleData,
-                    );
-                    AnalyticsService.instance.logViewMeal(
-                      schoolId: schoolId,
-                      mealDate: mealDate,
-                      dateOffset: _analyticsHelper.dateOffsetFromToday(
-                        _selectedDate,
-                      ),
-                      dataSource: AnalyticsDataSource.dbStaleFallback,
-                      mealCount: localData.length,
-                    );
-                  }
-                  // 3a. 로컬 데이터가 있으면, SnackBar를 띄우고 그 데이터를 반환합니다.
-                  _showStaleDataSnackbar(
-                    StaleDataException(
-                      localData,
-                      message: "새로고침에 실패했습니다. 오프라인 정보를 표시합니다.",
-                    ),
+            .catchError((e) {
+              if (e is StaleDataException) {
+                // API는 실패했지만 DB의 오래된 데이터는 사용 가능한 케이스입니다.
+                // stale 데이터 출처로 기록하고 사용자에게 안내 후 데이터를 유지합니다.
+                if (schoolId != null) {
+                  AnalyticsService.instance.logMealApiRequest(
+                    schoolId: schoolId,
+                    mealDate: mealDate,
+                    requestType: MealApiRequestType.userPullToRefresh,
+                    dataSource: _toAnalyticsDataSource(e.dataSource),
+                    triggerSource: AnalyticsTriggerSource.foreground,
+                    result: MealApiResult.staleData,
                   );
-                  return localData;
+                  AnalyticsService.instance.logViewMeal(
+                    schoolId: schoolId,
+                    mealDate: mealDate,
+                    dateOffset: _analyticsHelper.dateOffsetFromToday(
+                      _selectedDate,
+                    ),
+                    dataSource: _toAnalyticsDataSource(e.dataSource),
+                    mealCount: e.staleData.length,
+                  );
                 }
+                _showStaleDataSnackbar(
+                  StaleDataException(
+                    e.staleData,
+                    message: "새로고침에 실패했습니다. 오프라인 정보를 표시합니다.",
+                    dataSource: e.dataSource,
+                  ),
+                );
+                return e.staleData;
+              }
 
+              if (_isNetworkLikeError(e)) {
+                // stale fallback도 없는 순수 네트워크 실패입니다.
+                // 화면에서 의미 있는 오류 UI를 표시할 수 있도록 예외를 변환합니다.
                 if (schoolId != null) {
                   AnalyticsService.instance.logMealApiRequest(
                     schoolId: schoolId,
@@ -450,7 +495,6 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                     result: MealApiResult.networkError,
                   );
                 }
-                // 3b. 로컬 데이터조차 없으면 에러 화면을 보여줍니다.
                 if (_isTimeoutError(e)) {
                   throw const RequestTimeoutException();
                 }


### PR DESCRIPTION
## 📌 관련 이슈
Closes #46
Closes BOB-112

## ✨ 작업 내용
- `MealRepository` 식단 조회 정책을 단일 경로로 정리했습니다.
  - `getMealsForDateWithSource(..., {forceRefresh})` 중심
  - `forceRefreshMeals`는 공통 정책 함수로 위임
- 학교 변경 시 캐시 무효화 책임을 `UnivProvider`에서 `MealRepository`로 위임했습니다.
- `HomeScreen`에 학교 변경 명시 트리거를 추가했습니다.
  - `UnivProvider` 리스너 등록/해제
  - `schoolId` 변경 가드(`_lastKnownSchoolId`) 적용
  - 학교 변경 시 today 기준으로 즉시 재조회
- pull-to-refresh analytics의 `data_source`가 실제 fetch 결과를 반영하도록 수정했습니다.
  - 기존 고정 `api_fetched` 기록 제거
  - `StaleDataException` 분기에서 stale source 기준 로깅/노출 처리
- 유지보수를 위해 핵심 분기(리스너/가드/stale 처리)에 주석을 보강했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] PR 제목 규칙 준수
- [x] 빌드 테스트 완료 (`flutter analyze` 통과)
- [ ] API 서버 장애 복구 후 수동 시나리오 검증
  - [ ] 설정에서 학교 변경 후 홈 복귀 시 즉시 갱신
  - [ ] pull-to-refresh 성공/실패(stale/network) 분기 동작 확인
  - [ ] analytics `data_source` 기록 확인