### PR TITLE
[Feature] dotenv 기반 Amplitude 분석 도입 및 이벤트 전송 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ key.properties
 
 # Firebase
 android/app/google-services.json
+
+.env

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,8 +1,13 @@
 import 'dart:async';
 
+import 'package:amplitude_flutter/amplitude.dart';
+import 'package:amplitude_flutter/configuration.dart';
+import 'package:amplitude_flutter/events/base_event.dart';
+import 'package:amplitude_flutter/events/identify.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 enum AppGateDestinationRoute {
   home('/home'),
@@ -96,6 +101,9 @@ class AnalyticsService {
   AnalyticsService._();
 
   static final AnalyticsService instance = AnalyticsService._();
+
+  // Amplitude 인스턴스 추가
+  Amplitude? _amplitude;
   final FirebaseAnalytics _analytics = FirebaseAnalytics.instance;
   bool _isInitialized = false;
 
@@ -116,6 +124,7 @@ class AnalyticsService {
     if (_isInitialized) return;
     _isInitialized = true;
 
+    // Firebase 초기화
     try {
       await _analytics.setDefaultEventParameters({
         'env': environment,
@@ -126,7 +135,34 @@ class AnalyticsService {
       );
     } catch (error) {
       if (kDebugMode) {
-        debugPrint('[Analytics] initialize failed: $error');
+        debugPrint('[Analytics] Firebase initialize failed: $error');
+      }
+    }
+
+    // Amplitude & dotenv 초기화
+    try {
+      // pubspec.yaml에 assets: - .env 추가 필수!
+      await dotenv.load(fileName: ".env");
+      String? amplitudeKey = dotenv.env['AMPLITUDE_API_KEY'];
+
+      if (amplitudeKey != null && amplitudeKey.isNotEmpty) {
+        _amplitude = Amplitude(
+          Configuration(
+            apiKey: amplitudeKey,
+          ),
+        );
+        await _amplitude!.isBuilt;
+
+        final identify = Identify()..set('env', environment);
+        await _amplitude!.identify(identify);
+      } else {
+        if (kDebugMode) {
+          debugPrint('[Analytics] AMPLITUDE_API_KEY is missing in .env');
+        }
+      }
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('[Analytics] Amplitude initialize failed: $error');
       }
     }
   }
@@ -387,7 +423,7 @@ class AnalyticsService {
     parameters.forEach((key, value) {
       if (value == null) return;
 
-      if (value is String || value is int || value is double || value is bool) {
+      if (value is String || value is int || value is double) {
         normalized[key] = value;
         return;
       }
@@ -402,11 +438,29 @@ class AnalyticsService {
     required String name,
     required Map<String, Object> parameters,
   }) async {
+    // 1. Firebase 전송
     try {
       await _analytics.logEvent(name: name, parameters: parameters);
     } catch (error) {
       if (kDebugMode) {
-        debugPrint('[Analytics] logEvent failed: $name, error: $error');
+        debugPrint(
+          '[Analytics] Firebase logEvent failed: $name, error: $error',
+        );
+      }
+    }
+
+    // 2. Amplitude 전송
+    final amplitude = _amplitude;
+    if (amplitude == null) return;
+    try {
+      await amplitude.track(
+        BaseEvent(name, eventProperties: parameters),
+      );
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint(
+          '[Analytics] Amplitude logEvent failed: $name, error: $error',
+        );
       }
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.66"
+  amplitude_flutter:
+    dependency: "direct main"
+    description:
+      name: amplitude_flutter
+      sha256: "555ccf616bf816c16ed9a1c9f6f30181648756af3a5086e0fd4702c797497d4c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.0"
   analyzer:
     dependency: transitive
     description:
@@ -326,6 +334,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: d4130c4a43e0b13fefc593bc3961f2cb46e30cb79e253d4a526b1b5d24ae1ce4
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   provider: ^6.1.5+1
   url_launcher: ^6.3.1
   device_info_plus: ^12.3.0
+  flutter_dotenv: ^6.0.0
+  amplitude_flutter: ^4.5.0
 
 dev_dependencies:
   flutter_test:
@@ -58,6 +60,7 @@ flutter:
   default-flavor: prod
 
   assets:
+    - .env
     - assets/icons/
     - assets/fonts/
     


### PR DESCRIPTION
## 📌 관련 이슈
Closes #48
Closes BOB-116

## ✨ 작업 내용
- `amplitude_flutter` 도입 및 이벤트 전송/identify 로직 추가
  - `flutter_dotenv`로 `AMPLITUDE_API_KEY`를 `.env`에서 주입
  - 키 없거나 초기화/전송 실패 시 크래시 없이 로그만 남기도록 처리
- `.env`를 커밋/산출물에 포함하지 않도록 처리 (`pubspec.yaml` 자산 등록 + `.gitignore` 반영)

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] PR 제목 규칙 준수
- [x] 빌드 테스트 완료 (`flutter analyze` 통과)